### PR TITLE
Tombstoning fixes.

### DIFF
--- a/fair_identifiers_client/helpers.py
+++ b/fair_identifiers_client/helpers.py
@@ -80,3 +80,15 @@ def set_checksum_args(arguments):
     if checksum_args:
         arguments['checksums'] = checksum_args
     return arguments
+
+
+def parse_none_values(values, none_value='None'):
+    options = {}
+    for option_name, option_value, option_none_value in values:
+        if isinstance(option_value, str) and option_value == none_value:
+            options[option_name] = option_none_value
+        elif isinstance(option_value, list) and option_value == [none_value]:
+            options[option_name] = option_none_value
+        elif option_value:
+            options[option_name] = option_value
+    return options

--- a/fair_identifiers_client/main.py
+++ b/fair_identifiers_client/main.py
@@ -9,7 +9,7 @@ from fair_identifiers_client.identifiers_api import (identifiers_client, Identif
 from fair_identifiers_client.login import (LOGGED_IN_RESPONSE, LOGGED_OUT_RESPONSE, check_logged_in, do_link_login_flow,
                                            do_local_server_login_flow, revoke_tokens)
 from fair_identifiers_client.helpers import (subcommand, argument, clear_internal_args, load_metadata,
-                                             set_checksum_args)
+                                             set_checksum_args, parse_none_values)
 from argparse import ArgumentParser
 
 log = logging.getLogger(__name__)
@@ -332,8 +332,12 @@ def identifier_update(args):
     identifier_id = args.identifier
     args = clear_internal_args(vars(args))
     args = set_checksum_args(args)
-    if args.get('locations'):
-        args['location'] = args.pop('locations')
+    optional_values = [
+        ('replaces', args['replaces'], None),
+        ('replaced_by', args['replaced_by'], None),
+        ('location', args['locations'], [])
+    ]
+    args = (parse_none_values(optional_values))
     activate = args.get('activate')
     deactivate = args.get('deactivate')
     if activate and deactivate:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(BASE_DIR, 'README.md')) as f:
 
 setup(
     name='fair-identifiers-client',
-    version='0.4.0.dev0',
+    version='0.4.1.dev0',
     url='https://github.com/fair-research/fair-identifiers-client',
     author="FAIR Research Team",
     description='FAIR Research Identifiers Service Client',


### PR DESCRIPTION
Allow tombstoning variables "replaces" and "replaced_by" to be "unset via update API.

Support unsetting of locations, replaced_by, and replaces via keyword "None" as an argument in the CLI.
Bump version.